### PR TITLE
Use published 1.2 versions instead of SNAPSHOTs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,8 +2,8 @@
 
 // Provide a managed dependency on X if -DXVersion="" is supplied on the command line.
 val defaultVersions = Map(
-  "dsptools" -> "1.2-SNAPSHOT",
-  "rocket-dsptools" -> "1.2-SNAPSHOT",
+  "dsptools" -> "1.2.+",
+  "rocket-dsptools" -> "1.2.+",
   "firesim" -> "1.0"
 )
 


### PR DESCRIPTION
This changes the dsptools/rocket-dsptools library dependencies to use published versions instead of snapshots. I have bad luck with snapshots generally and it makes it more onerous to get CI working (e.g., with a project that is using this as a submodule).